### PR TITLE
chore: include optional params

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -86,10 +86,10 @@ export class Tinybird {
       revalidate?: number;
     };
   }): (
-    params: TParameters,
+    params?: TParameters,
   ) => Promise<z.infer<typeof pipeResponseWithoutData> & { data: TData[] }> {
     const outputSchema = pipeResponseWithoutData.setKey("data", z.array(req.data));
-    return async (params: TParameters) => {
+    return async (params?: TParameters) => {
       let validatedParams: TParameters | undefined = undefined;
       if (req.parameters) {
         const v = req.parameters.safeParse(params);


### PR DESCRIPTION
Just a small addition to allow undefined params:

```ts
tb.buildPipe({
  pipe: "get_channel_activity__v1",
  parameters: z.object({
    start: z.number().int().default(0),
    end: z.number().int().optional(),
    limit: z.number().int().optional().default(50),
  }),
  data: z.object({
    // ...
  }),
})(); // `{}` where needed before
```

