### PR TITLE
fix: zod input/output types

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -80,12 +80,12 @@ export class Tinybird {
     };
   }
 
-  public buildIngestEndpoint<TEvent extends Record<string, unknown>,>(req: {
+  public buildIngestEndpoint<TOutput extends Record<string, unknown>, TInput = TOutput>(req: {
     datasource: string;
-    event: z.ZodSchema<TEvent, any, any>;
-  }): (events: TEvent | TEvent[]) => Promise<z.infer<typeof eventIngestReponseData>> {
-    return async (events: TEvent | TEvent[]) => {
-      let validatedEvents: typeof events | undefined = undefined;
+    event: z.ZodSchema<TOutput, z.ZodTypeDef, TInput>;
+  }): (events: TInput | TInput[]) => Promise<z.infer<typeof eventIngestReponseData>> {
+    return async (events: TInput | TInput[]) => {
+      let validatedEvents: TOutput | TOutput[] | undefined = undefined;
       if (req.event) {
         const v = Array.isArray(events)
           ? req.event.array().safeParse(events)

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -83,4 +83,14 @@ export const publishEvents = tb.buildIngestEndpoint({
   }),
 });
 
+export const publishTransformedEvents = tb.buildIngestEndpoint({
+  datasource: "events__v1",
+  event: z.object({
+    actor: z
+      .object({ id: z.string(), name: z.string() })
+      .transform((val) => JSON.stringify(val)),
+  }),
+});
+
 // await publishEvents([{ id: "1" }, { id: "2" }])
+// await publishTransformedEvents({ actor: { id: "1", name: "John" } });

--- a/src/noop.ts
+++ b/src/noop.ts
@@ -52,12 +52,12 @@ export class NoopTinybird {
     };
   }
 
-  public buildIngestEndpoint<TEvent extends Record<string, unknown>,>(req: {
+  public buildIngestEndpoint<TOutput extends Record<string, unknown>, TInput = TOutput>(req: {
     datasource: string;
-    event: z.ZodSchema<TEvent, any, any>;
-  }): (events: TEvent | TEvent[]) => Promise<z.infer<typeof eventIngestReponseData>> {
-    return async (events: TEvent | TEvent[]) => {
-      let validatedEvents: typeof events | undefined = undefined;
+    event: z.ZodSchema<TOutput, z.ZodTypeDef, TInput>;
+  }): (events: TInput | TInput[]) => Promise<z.infer<typeof eventIngestReponseData>> {
+    return async (events: TInput | TInput[]) => {
+      let validatedEvents: TOutput | TOutput[] | undefined = undefined;
       if (req.event) {
         const v = req.event.safeParse(events);
         if (!v.success) {


### PR DESCRIPTION
### Issue

When using `transform` to change the data type, the `buildIngestEndpoint` would only consider the `Output` types instead of the `Input` type.

```js
const publishEvents = tb.buildIngestEndpoint({
  datasource: "events__v1",
  event: z.object({
    actor: z
      .object({ id: z.string(), name: z.string() })
      .transform((val) => JSON.stringify(val)),
  }),
});

await publishEvents({ actor: { id: "1", name: "John" } });
// ^? <{ actor: string }> TS Error
```

The `actor` expects to be the transformed string. I want it to be the the input object schema.

### Solution

[ZodType with ZodEffects](https://zod.dev/?id=zodtype-with-zodeffects)

A type is defined as: `z.ZodSchema<Output, z.ZodTypeDef, Input>` where we have the input and output type of our schema.

I have replaced `TEvent` with `TOutput` to match the wording.

The examples have been extended with that use case.

Let me know what you think!