### PR TITLE
Fix cache revalidation for nextjs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ tb.buildPipe({
     response: z.string()
   }),
    opts: {
-      revalidate: 900 ;// <-------- Add this
+      next: {
+        revalidate: 900 ;// <-------- Add this
+      }
     };
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -62,7 +62,9 @@ export class Tinybird {
       /**
        * Number of seconds to revalidate the cache
        */
-      revalidate?: number;
+      next?:{
+        revalidate?: number;
+      }
     };
   }): (
     params: z.input<TParameters>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -62,9 +62,9 @@ export class Tinybird {
       /**
        * Number of seconds to revalidate the cache
        */
-      next?:{
+      next?: {
         revalidate?: number;
-      }
+      };
     };
   }): (
     params: z.input<TParameters>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,7 +32,15 @@ export class Tinybird {
 
   private async fetch(
     url: string | URL,
-    opts: { method: string; headers?: Record<string, string>; body?: string },
+    opts: {
+      method: string;
+      headers?: Record<string, string>;
+      body?: string;
+      cache?: RequestCache;
+      next?: {
+        revalidate?: number;
+      };
+    },
   ): Promise<unknown> {
     for (let i = 0; i < 10; i++) {
       const res = await fetch(url, opts);
@@ -59,10 +67,10 @@ export class Tinybird {
     data: TData;
     opts?: {
       cache?: RequestCache;
-      /**
-       * Number of seconds to revalidate the cache
-       */
       next?: {
+        /**
+         * Number of seconds to revalidate the cache (nextjs specific)
+         */
         revalidate?: number;
       };
     };
@@ -92,6 +100,7 @@ export class Tinybird {
         }
       }
       const res = await this.fetch(url, {
+        ...req.opts,
         method: "GET",
         headers: { Authorization: `Bearer ${this.token}` },
       });


### PR DESCRIPTION
When we want to revalidate cache for a specific fetch request we need to pass the `next.revalidate` options 

https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate  