### PR TITLE
Add support for unauthorized responses 

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -52,6 +52,11 @@ export class Tinybird {
         await new Promise((r) => setTimeout(r, 1000 + i ** 2 * 50));
         continue;
       }
+
+      if (res.status === 403) {
+        throw new Error("Unauthorized");
+      }
+
       if (!res.ok) {
         const error = (await res.json()) as PipeErrorResponse;
         throw new Error(error.error);


### PR DESCRIPTION
## Current behaviour
Trying to send data to the Events API with an unauthorized token returns `Failed to parse JSON`  as res.json() throws an error because it cannot be obtained.

## Desired behaviour
Using an unauthorized token to throw Unauthorized as the error message rather than Failed to parse JSON as it can be misleading

I feel like adding:
```
 if (res.status === 403) {
        throw new Error("Unauthorized");
      }
```
to the fetch function on `client.ts` would solve the issue